### PR TITLE
surround disconnect in try / IOError except

### DIFF
--- a/gretis/__init__.py
+++ b/gretis/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 VERSION = tuple(map(int, __version__.split('.')))

--- a/gretis/async_connection.py
+++ b/gretis/async_connection.py
@@ -252,13 +252,15 @@ class AsyncConnection(Connection):
         if self._iostream is None:
             return
 
-        if self._timeout_handle:
-            self._ioloop.remove_timeout(self._timeout_handle)
-            self._timeout_handle = None
-        self._iostream.set_close_callback(None)
-        self._iostream.close()
+        try:
+            if self._timeout_handle:
+                self._ioloop.remove_timeout(self._timeout_handle)
+                self._timeout_handle = None
+            self._iostream.set_close_callback(None)
+            self._iostream.close()
+        except socket.error:
+            pass
         self._iostream = None
-
         # This will call into the AsynchiredisParser on_disconnect.
         super(AsyncConnection, self).disconnect()
 


### PR DESCRIPTION
if _iostream is already closed, it will raise a socket.error (Bad file descriptor [Errno 9]). This fix will try / catch for this. A similar try / catch is done in the disconnect method in the Connection class (parent of AsyncConnection).